### PR TITLE
:#53 Moving Event factories to separate namespace

### DIFF
--- a/spec/EventFactory/PushEvent/PusherFactorySpec.php
+++ b/spec/EventFactory/PushEvent/PusherFactorySpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Devboard\GitHub\Webhook\Core\Event\PushEvent;
+namespace spec\Devboard\GitHub\Webhook\Core\EventFactory\PushEvent;
 
 use Devboard\GitHub\Webhook\Core\Event\PushEvent\Pusher;
-use Devboard\GitHub\Webhook\Core\Event\PushEvent\PusherFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\PushEvent\PusherFactory;
 use PhpSpec\ObjectBehavior;
 
 class PusherFactorySpec extends ObjectBehavior

--- a/spec/EventFactory/PushEventFactorySpec.php
+++ b/spec/EventFactory/PushEventFactorySpec.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace spec\Devboard\GitHub\Webhook\Core\Event;
+namespace spec\Devboard\GitHub\Webhook\Core\EventFactory;
 
 use Devboard\GitHub\GitHubCommit;
 use Devboard\GitHub\GitHubRepo;
 use Devboard\GitHub\Webhook\Core\Commit\GitHubCommitFactory;
 use Devboard\GitHub\Webhook\Core\Event\PushEvent;
 use Devboard\GitHub\Webhook\Core\Event\PushEvent\Pusher;
-use Devboard\GitHub\Webhook\Core\Event\PushEvent\PusherFactory;
-use Devboard\GitHub\Webhook\Core\Event\PushEventFactory;
 use Devboard\GitHub\Webhook\Core\Event\Sender;
-use Devboard\GitHub\Webhook\Core\Event\SenderFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\PushEvent\PusherFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\PushEventFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\SenderFactory;
 use Devboard\GitHub\Webhook\Core\Repo\GitHubRepoFactory;
 use PhpSpec\ObjectBehavior;
 

--- a/spec/EventFactory/SenderFactorySpec.php
+++ b/spec/EventFactory/SenderFactorySpec.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace spec\Devboard\GitHub\Webhook\Core\Event;
+namespace spec\Devboard\GitHub\Webhook\Core\EventFactory;
 
 use Devboard\GitHub\Webhook\Core\Event\Sender;
-use Devboard\GitHub\Webhook\Core\Event\SenderFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\SenderFactory;
 use PhpSpec\ObjectBehavior;
 
 class SenderFactorySpec extends ObjectBehavior

--- a/src/EventFactory/PushEvent/PusherFactory.php
+++ b/src/EventFactory/PushEvent/PusherFactory.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Devboard\GitHub\Webhook\Core\Event\PushEvent;
+namespace Devboard\GitHub\Webhook\Core\EventFactory\PushEvent;
+
+use Devboard\GitHub\Webhook\Core\Event\PushEvent\Pusher;
 
 /**
  * @see PusherFactorySpec

--- a/src/EventFactory/PushEventFactory.php
+++ b/src/EventFactory/PushEventFactory.php
@@ -2,14 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Devboard\GitHub\Webhook\Core\Event;
+namespace Devboard\GitHub\Webhook\Core\EventFactory;
 
 use Devboard\GitHub\Commit\GitHubCommitSha;
 use Devboard\GitHub\Webhook\Core\Commit\GitHubCommitFactory;
 use Devboard\GitHub\Webhook\Core\CompareChangesUrl;
-use Devboard\GitHub\Webhook\Core\Event\PushEvent\PusherFactory;
+use Devboard\GitHub\Webhook\Core\Event\PushEvent;
 use Devboard\GitHub\Webhook\Core\Event\PushEvent\PushEventState;
 use Devboard\GitHub\Webhook\Core\Event\PushEvent\Ref;
+use Devboard\GitHub\Webhook\Core\EventFactory\PushEvent\PusherFactory;
 use Devboard\GitHub\Webhook\Core\GitHubCommitCollection;
 use Devboard\GitHub\Webhook\Core\Repo\GitHubRepoFactory;
 

--- a/src/EventFactory/SenderFactory.php
+++ b/src/EventFactory/SenderFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Devboard\GitHub\Webhook\Core\Event;
+namespace Devboard\GitHub\Webhook\Core\EventFactory;
 
 use Devboard\GitHub\User\GitHubUserApiUrl;
 use Devboard\GitHub\User\GitHubUserAvatarUrl;
@@ -11,6 +11,7 @@ use Devboard\GitHub\User\GitHubUserHtmlUrl;
 use Devboard\GitHub\User\GitHubUserId;
 use Devboard\GitHub\User\GitHubUserLogin;
 use Devboard\GitHub\User\GitHubUserTypeFactory;
+use Devboard\GitHub\Webhook\Core\Event\Sender;
 
 /**
  * @see SenderFactorySpec

--- a/tests/EventFactory/PushEventFactoryTest.php
+++ b/tests/EventFactory/PushEventFactoryTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace tests\Devboard\GitHub\Webhook\Core\Event;
+namespace tests\Devboard\GitHub\Webhook\Core\EventFactory;
 
 use Devboard\GitHub\Webhook\Core\Commit\GitHubCommitAuthorFactory;
 use Devboard\GitHub\Webhook\Core\Commit\GitHubCommitCommitterFactory;
 use Devboard\GitHub\Webhook\Core\Commit\GitHubCommitFactory;
 use Devboard\GitHub\Webhook\Core\Event\PushEvent;
-use Devboard\GitHub\Webhook\Core\Event\PushEvent\PusherFactory;
-use Devboard\GitHub\Webhook\Core\Event\PushEventFactory;
-use Devboard\GitHub\Webhook\Core\Event\SenderFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\PushEvent\PusherFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\PushEventFactory;
+use Devboard\GitHub\Webhook\Core\EventFactory\SenderFactory;
 use Devboard\GitHub\Webhook\Core\Repo\GitHubRepoEndpointsFactory;
 use Devboard\GitHub\Webhook\Core\Repo\GitHubRepoFactory;
 use Devboard\GitHub\Webhook\Core\Repo\GitHubRepoStatsFactory;
@@ -19,7 +19,7 @@ use Devboard\Thesting\Source\JsonSource;
 use Generator;
 
 /**
- * @covers \Devboard\GitHub\Webhook\Core\Event\PushEventFactory
+ * @covers \Devboard\GitHub\Webhook\Core\EventFactory\PushEventFactory
  * @group  unit
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)


### PR DESCRIPTION
With adding all other GitHub events, Event namespace will get crowded
quickly.

Closes #53